### PR TITLE
Check data against list of values

### DIFF
--- a/src/Criteria/Equals.php
+++ b/src/Criteria/Equals.php
@@ -23,6 +23,11 @@ class Equals extends \Psecio\Canary\Criteria
     public function evaluate(Data $input)
     {
         $val = $input->resolve($this->key);
+
+        if (is_array($this->value) && in_array($val, $this->value, false)) {
+            return true;
+        }
+
         return ($val == $this->value);
     }
 


### PR DESCRIPTION
Added a couple of baseline tests first.

`in_array` is explicitly not strict, because the fallback equivalency check is also loose. Should looseness be configurable? Does this logic warrant additional Criteria classes? I think that would increase the complexity of Instance.