### PR TITLE
Execute config without Notify edge-case exception

### DIFF
--- a/src/Instance.php
+++ b/src/Instance.php
@@ -237,6 +237,9 @@ class Instance
     {
         $match = false;
         $defaultNotify = $this->getConfig('notify');
+        if (!$defaultNotify instanceof Notify && !is_callable($defaultNotify)) {
+            $defaultNotify = null;
+        }
 
         foreach ($criteria as $index => $instance) {
             if ($instance instanceof CriteriaSet) {

--- a/tests/InstanceTest.php
+++ b/tests/InstanceTest.php
@@ -264,4 +264,29 @@ class InstanceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($result);
     }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Whoops!
+     */
+    public function testConfigWithoutNotify()
+    {
+        $config = [
+            'data' => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $criteria = [
+            'foo' => 'bar',
+            'baz' => 'quux',
+        ];
+
+        Instance::build($config)
+            ->if($criteria)
+            ->then(function () {
+                throw new \UnexpectedValueException('Whoops!');
+            })
+            ->execute();
+    }
 }


### PR DESCRIPTION
Ran into a scenario where an Instance configured with data and without notify (which is set fluently) crashes during execution. Probably an extreme edge case, but I added a check to make sure the defaultNotify is an appropriate type. Could slurp that into a private method if you'd like, but I wanted to keep the diff small at first.

Is it intended for getConfig to return the whole config if an explicitly requested key does not exist?